### PR TITLE
build: Streamline backend Docker image creation and context

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,22 @@
+# === General ===
+.git
+.gitignore
+Dockerfile
+README.md
+
+# === Java build artifacts ===
+target/
+build/
+.gradle/
+out/
+*.class
+
+# === IDE noise ===
+*.iml
+.idea/
+.vscode/
+
+# === Logs & OS noise ===
+*.log
+.DS_Store
+Thumbs.db

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,31 +1,48 @@
-#Это так называемый мультистейдж docker-файл. Сначала делаем образ, который соберёт нам java-приложение,
-#а затем из него берём собранный артефакт и кладём его в новый образ, чтобы оставить в нём меньше лишнего
+# ---------- Build Stage ----------
+ARG VERSION=0.1.0-SNAPSHOT
 
-# build
-FROM maven:3.8.2-openjdk-16-slim as builder
-# задаём переменную VERSION, которая будет использоваться для сборки проекта
-ARG VERSION=${VERSION}
+FROM maven:3.8.2-openjdk-16-slim AS builder
+ARG VERSION
+
+# Устанавливаем рабочую директорию
 WORKDIR /usr/src/app
+
+# Копируем файл зависимостей и загружаем их
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+# Копируем исходный код
 COPY ./src ./src
-COPY *.xml ./
 
-RUN mvn package -Dversion.application=${VERSION}
+# Сборка проекта без тестов и переименование JAR-файла
+RUN mvn clean package -DskipTests -DVERSION=${VERSION} \
+    && cp target/sausage-store-${VERSION}.jar target/sausage-store.jar
 
-# release
-FROM openjdk:16-jdk-alpine
-ARG VERSION=${VERSION}
+# ---------- Production Stage ----------
+FROM amazoncorretto:17-alpine
+
+# Создаем рабочую директорию приложения
 WORKDIR /app
-# создаём пользователя jaruser
+
+# Создаем системного пользователя
 RUN addgroup --system jaruser \
     && adduser -S -s /bin/false -G jaruser jaruser -D -H \
-    && apk add --no-cache dumb-init==1.2.5-r0 \
-    && apk add --update curl \
-    && rm -rf /var/cache/apk/* \
+    && apk add --no-cache dumb-init curl netcat-openbsd \
     && mkdir -p /logs/reports \
     && chown -R jaruser:jaruser /logs
-COPY --chown=jaruser:jaruser \
-     --from=builder /usr/src/app/target/sausage-store-${VERSION}.jar ./sausage-store.jar
+
+# Копируем JAR с правильными правами доступа
+COPY --chown=jaruser:jaruser --from=builder /usr/src/app/target/sausage-store.jar ./sausage-store.jar
+
+# Открываем порт
 EXPOSE 8080
-# приложение будет запускаться под пользователем jaruser
+
+# Запускаем от имени jaruser
 USER jaruser
+
+# Конфигурация healthcheck
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
+
+# Запуск приложения с dumb-init
 ENTRYPOINT ["dumb-init", "java", "-jar", "-Dmyserver.bindPort=8080", "./sausage-store.jar"]


### PR DESCRIPTION
#comment Generate dockerignore for Java service and rework Maven multistage Dockerfile to use Amazon Corretto runtime, non-root user and healthcheck.

Affected: backend/.dockerignore, backend/Dockerfile