### PR TITLE
chore: Align Helm ignore lists to discard build artefacts

### DIFF
--- a/sausage-store-chart/.helmignore
+++ b/sausage-store-chart/.helmignore
@@ -1,23 +1,22 @@
-# Patterns to ignore when building packages.
-# This supports shell glob matching, relative path matching, and
-# negation (prefixed with !). Only one pattern per line.
+# === Common build artifacts ===
+*.tgz
+*.tar.gz
+*.zip
+
+# === OS junk ===
 .DS_Store
-# Common VCS dirs
+Thumbs.db
+
+# === IDE configs ===
+.idea/
+.vscode/
+*.iml
+
+# === Git ===
 .git/
 .gitignore
-.bzr/
-.bzrignore
-.hg/
-.hgignore
-.svn/
-# Common backup files
-*.swp
-*.bak
-*.tmp
-*.orig
-*~
-# Various IDEs
-.project
-.idea/
-*.tmproj
-.vscode/
+
+# === Docs and README ===
+README.md
+LICENSE
+CHANGELOG.md

--- a/sausage-store-chart/charts/backend-report/.helmignore
+++ b/sausage-store-chart/charts/backend-report/.helmignore
@@ -1,0 +1,20 @@
+# === Helm build artifacts ===
+*.tgz
+*.tar.gz
+
+# === Editor and system junk ===
+*.swp
+.DS_Store
+Thumbs.db
+
+# === Version control ===
+.git/
+.gitignore
+
+# === IDE ===
+.idea/
+.vscode/
+
+# === Docs ===
+README.md
+LICENSE


### PR DESCRIPTION
#comment Expand root and component helmignore files to omit archives, editor files and docs accelerating chart packaging.

Affected: sausage-store-chart/.helmignore, charts/backend-report/.helmignore