### PR TITLE
feat: Package backend-report microservice as standalone Helm subchart

### DIFF
--- a/sausage-store-chart/Chart.yaml
+++ b/sausage-store-chart/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 type: application
-name: sausage-store
+name: sausage-store-chart
 description: Sausage Store Helm Chart
 
 version: 0.1.0

--- a/sausage-store-chart/charts/backend-report/Chart.yaml
+++ b/sausage-store-chart/charts/backend-report/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+type: application
+name: backend-report
+description: backend reports Helm Chart
+
+version: 0.1.0
+appVersion: "latest"

--- a/sausage-store-chart/charts/backend-report/templates/deployment.yaml
+++ b/sausage-store-chart/charts/backend-report/templates/deployment.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ printf "%s-%s" .Release.Name .Chart.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+spec:
+  strategy:
+    type: {{ .Values.strategy.type }}
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      initContainers:
+        - name: wait-for-mongodb
+          image: busybox:1.35
+          command: ['sh', '-c', 'until nc -z mongodb 27017; do echo "Waiting for MongoDB..."; sleep 5; done']
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ .Values.image }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - containerPort: {{ .Values.containerPort }}
+              name: http
+          env:
+            - name: PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ printf "%s-%s-conf" .Release.Name .Chart.Name }}
+                  key: port
+            - name: DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-%s-secret" .Release.Name .Chart.Name }}
+                  key: db
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            initialDelaySeconds: 45
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 30
+            successThreshold: 1
+            timeoutSeconds: 5
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s-conf" .Release.Name .Chart.Name }}
+data:
+  port: "{{ .Values.config.port }}"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s-secret" .Release.Name .Chart.Name }}
+type: Opaque
+data:
+  db: {{ .Values.secret.db | b64enc }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ printf "%s-%s-hpa" .Release.Name .Chart.Name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ printf "%s-%s" .Release.Name .Chart.Name }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}

--- a/sausage-store-chart/charts/backend-report/templates/service.yaml
+++ b/sausage-store-chart/charts/backend-report/templates/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-%s" .Release.Name .Chart.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
#comment Define chart metadata, deployment with init-container, service and register dependency in umbrella chart enabling independent release cycle

Affected: sausage-store-chart/Chart.yaml, charts/backend-report/Chart.yaml, charts/backend-report/templates/deployment.yaml, charts/backend-report/templates/service.yaml