### PR TITLE
feat: Ship front-end through dedicated Helm subchart with TLS ingress

### DIFF
--- a/sausage-store-chart/charts/frontend/Chart.yaml
+++ b/sausage-store-chart/charts/frontend/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+type: application
+name: frontend
+description: Frontend chart for Sausage Store
+
+version: 0.1.0
+appVersion: "latest"

--- a/sausage-store-chart/charts/frontend/templates/configmap.yaml
+++ b/sausage-store-chart/charts/frontend/templates/configmap.yaml
@@ -36,7 +36,7 @@ data:
           }
 
             location /api {
-              proxy_pass http://{{ .Release.Name }}-backend-service:8080;
+              proxy_pass http://{{ .Release.Name }}-backend:8080;
           }
 
           error_page   500 502 503 504  /50x.html;

--- a/sausage-store-chart/charts/frontend/templates/deployment.yaml
+++ b/sausage-store-chart/charts/frontend/templates/deployment.yaml
@@ -19,21 +19,44 @@ spec:
     type: {{ .Values.strategy.type }}
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-{{ .Chart.Name }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-{{ .Chart.Name }}
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+        app.kubernetes.io/component: {{ .Chart.Name }}
+        app.kubernetes.io/part-of: {{ .Release.Name }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           resources:
-{{ toYaml .Values.resources | indent 12 }} 
+{{ toYaml .Values.resources | indent 12 }}
           ports:
             - name: {{ .Chart.Name }}
               containerPort: {{ .Values.containerPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+            successThreshold: 1
           volumeMounts:
           - name: {{ .Release.Name }}-{{ .Chart.Name }}-conf
             mountPath: /etc/nginx/{{ .Values.nginxConf }}
@@ -45,4 +68,4 @@ spec:
             name: {{ .Release.Name }}-{{ .Chart.Name }}-conf
             items:
               - key: {{ .Values.nginxConf }}
-                path: {{ .Values.nginxConf }} 
+                path: {{ .Values.nginxConf }}

--- a/sausage-store-chart/charts/frontend/templates/ingress.yaml
+++ b/sausage-store-chart/charts/frontend/templates/ingress.yaml
@@ -8,6 +8,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tlsSecretName }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:
@@ -16,6 +17,6 @@ spec:
           pathType: {{ .Values.ingress.pathType }}
           backend:
             service:
-              name: {{ .Release.Name }}-{{ .Chart.Name }}-service
+              name: {{ .Values.service.name }}
               port:
                 number: {{ .Values.service.port }}

--- a/sausage-store-chart/charts/frontend/templates/service.yaml
+++ b/sausage-store-chart/charts/frontend/templates/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name | default (printf "%s-%s-service" .Release.Name .Chart.Name) }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.containerPort }}


### PR DESCRIPTION
#comment Create metadata and manifests for deployment, service, nginx configmap and HTTPS ingress leveraging global values for host and replicas

Affected: charts/frontend/Chart.yaml, charts/frontend/templates/configmap.yaml, charts/frontend/templates/deployment.yaml, charts/frontend/templates/ingress.yaml, charts/frontend/templates/service.yaml