### PR TITLE
feat: Provision MongoDB and PostgreSQL StatefulSets with PVCs

### DIFF
--- a/sausage-store-chart/charts/infra/templates/mongodb.yaml
+++ b/sausage-store-chart/charts/infra/templates/mongodb.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -29,9 +30,17 @@ spec:
             cpu: "50m"
           limits:
             memory: "256Mi"
+            cpu: 250m
         volumeMounts:
         - name: mongodb-data
           mountPath: /data/db
+        - name: init-script
+          mountPath: /docker-entrypoint-initdb.d/init-user.js
+          subPath: init-user.js
+      volumes:
+      - name: init-script
+        configMap:
+          name: mongodb-init-script
   volumeClaimTemplates:
   - metadata:
       name: mongodb-data
@@ -62,3 +71,17 @@ metadata:
 data:
   MONGO_INITDB_ROOT_USERNAME: {{ .Values.mongodb.env.MONGO_INITDB_ROOT_USERNAME }}
   MONGO_INITDB_ROOT_PASSWORD: {{ .Values.mongodb.env.MONGO_INITDB_ROOT_PASSWORD }}
+  MONGO_INITDB_DATABASE: {{ .Values.mongodb.env.MONGO_INITDB_DATABASE }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongodb-init-script
+data:
+  init-user.js: |
+    db = db.getSiblingDB("{{ .Values.mongodb.env.MONGO_INITDB_DATABASE }}");
+    db.createUser({
+      user: "{{ .Values.mongodb.env.MONGO_REPORT_USER }}",
+      pwd: "{{ .Values.mongodb.env.MONGO_REPORT_PASSWORD }}",
+      roles: [ { role: "readWrite", db: "{{ .Values.mongodb.env.MONGO_INITDB_DATABASE }}" } ]
+    });

--- a/sausage-store-chart/charts/infra/templates/postgres.yaml
+++ b/sausage-store-chart/charts/infra/templates/postgres.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  annotations:
+    helm.sh/hook-weight: "-5"
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:14
+        envFrom:
+          - configMapRef:
+              name: postgres-conf
+        ports:
+        - containerPort: {{ .Values.postgres.containerPort }}
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+        volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/postgresql
+  volumeClaimTemplates:
+  - metadata:
+      name: postgres-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  ports:
+  - port: {{ .Values.postgres.containerPort }}
+    targetPort: {{ .Values.postgres.containerPort }}
+  selector:
+    app: postgres
+  clusterIP: None
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-conf
+data:
+  POSTGRES_USER: {{ .Values.postgres.auth.username }}
+  POSTGRES_PASSWORD: {{ .Values.postgres.auth.password }}
+  POSTGRES_DB: {{ .Values.postgres.auth.database }}


### PR DESCRIPTION
#comment Introduce secure ConfigMaps, init script volume and persistence for MongoDB and add PostgreSQL StatefulSet with dedicated PVC improving data durability.

Affected: charts/infra/templates/mongodb.yaml, charts/infra/templates/postgres.yaml